### PR TITLE
add '-lm'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build-lib:
 	cd src; \
 	  yacc -d parse.y; \
 	  lex scan.l
-	$(CC) $(CFLAGS) -shared src/*.c -o lib/libpicrin.so -I./include -I./extlib
+	$(CC) $(CFLAGS) -shared src/*.c -o lib/libpicrin.so -I./include -I./extlib -lm
 
 clean:
 	rm -f src/y.tab.c src/y.tab.h src/lex.yy.c


### PR DESCRIPTION
I got following errors on Linux(GCC).
`libm` must be linked because `src/number.c` uses some math library, `cos`, `sin` etc.

```
gcc -Wall -O3 -g -DDEBUG=1 tools/main.c -o bin/picrin -I./include -L./lib -lpicrin -lreadline
./lib/libpicrin.so: undefined reference to `lround'
./lib/libpicrin.so: undefined reference to `atan2'
./lib/libpicrin.so: undefined reference to `acos'
./lib/libpicrin.so: undefined reference to `sin'
./lib/libpicrin.so: undefined reference to `atan'
./lib/libpicrin.so: undefined reference to `asin'
./lib/libpicrin.so: undefined reference to `exp'
./lib/libpicrin.so: undefined reference to `trunc'
./lib/libpicrin.so: undefined reference to `tan'
./lib/libpicrin.so: undefined reference to `cos'
./lib/libpicrin.so: undefined reference to `log'
./lib/libpicrin.so: undefined reference to `pow'
```
