### PR TITLE
fix typo of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Picrin - a lightweight scheme interpreter
 
-## Freatures
+## Features
 
 - R7RS compatibility (but partial support)
 - reentrant design (all VM states are stored in single global state object)


### PR DESCRIPTION
change "Freatures" to "Features" on README
