### PR TITLE
Include string.h and stdlib.h at all time.

### DIFF
--- a/tools/main.c
+++ b/tools/main.c
@@ -1,12 +1,12 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "picrin.h"
 #include "picrin/pair.h"
 
 #if PIC_ENABLE_READLINE
-# include <string.h>
-# include <stdlib.h>
 # include <readline/readline.h>
 # include <readline/history.h>
 #endif


### PR DESCRIPTION
Even if readline support is disabled, some functions declared in
string.h and stdlib.h are used. (e.g. strlen and exit)
