### PR TITLE
Add (import ...) to etc/tak.scm and t/*.scm.

### DIFF
--- a/etc/tak.scm
+++ b/etc/tak.scm
@@ -1,3 +1,7 @@
+(import (scheme base)
+        (scheme time)
+        (scheme write))
+
 (define (time f)
   (let ((start (current-jiffy)))
     (f)

--- a/t/closure.scm
+++ b/t/closure.scm
@@ -1,3 +1,6 @@
+(import (scheme base)
+        (scheme write))
+
 (begin
 
  (define foo (lambda (a)

--- a/t/dynamic-wind.scm
+++ b/t/dynamic-wind.scm
@@ -1,3 +1,6 @@
+(import (scheme base)
+        (scheme write))
+
 (define (print obj)
   (write obj)
   (newline)

--- a/t/exception.scm
+++ b/t/exception.scm
@@ -1,3 +1,6 @@
+(import (scheme base)
+        (scheme write))
+
 (define (print obj)
   (write obj)
   (newline)

--- a/t/ir-macro.scm
+++ b/t/ir-macro.scm
@@ -1,3 +1,6 @@
+(import (scheme base)
+        (picrin macro))
+
 (define-syntax aif
   (ir-macro-transformer
    (lambda (form inject cmp)

--- a/t/letrec.scm
+++ b/t/letrec.scm
@@ -1,3 +1,6 @@
+(import (scheme base)
+        (scheme write))
+
 (define (print obj)
   (write obj)
   (newline)

--- a/t/tailcall.scm
+++ b/t/tailcall.scm
@@ -1,6 +1,10 @@
+(import (scheme base)
+        (scheme write))
+
 (define (sum k acc)
   (if (zero? k)
       acc
       (sum (- k 1) (+ k acc))))
 
-(display (sum 1000 0))
+(write (sum 1000 0))
+(newline)


### PR DESCRIPTION
Note that this commit only fixes 'unbound variable' errors. For now
t/dynamic-wind.scm, t/exception.scm and t/ir-macro.scm seem buggy on my
Linux (amd64) machine.
