### PR TITLE
Use C99 + GNU extensions (-std=gnu99) by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Wall
+CFLAGS= -std=gnu99 -Wall
 
 ifeq ($(findstring CYGWIN,$(shell uname -s)), CYGWIN)
   PICRIN_LIB=cygpicrin.dll


### PR DESCRIPTION
Without -std=\* option, gcc assumes it is gnu89 source, though clang does
it is gnu99 source.

I'd suggest using gnu99 by default. We are in the 21st century.
