### PR TITLE
Define the type of marking flags as unsigned int.

### DIFF
--- a/include/picrin/gc.h
+++ b/include/picrin/gc.h
@@ -9,16 +9,14 @@
 extern "C" {
 #endif
 
-enum pic_gc_mark {
-  PIC_GC_UNMARK = 0,
-  PIC_GC_MARK
-};
+#define PIC_GC_UNMARK 0
+#define PIC_GC_MARK 1
 
 union header {
   struct {
     union header *ptr;
     size_t size;
-    enum pic_gc_mark mark : 1;
+    unsigned int mark : 1;
   } s;
   long alignment[2];
 };


### PR DESCRIPTION
We could define it as _Bool since we are going to use C99, but unsigned
int is more portable (even in C89!) and extensible (when we decide to
use tri-color marking GC.)

By the way, `long alignment[2]` is still effective when picrin is built for an ILP32 arch?
