### PR TITLE
Fix analyze errer for (+) and (*)

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -561,7 +561,7 @@ analyze_add(analyze_state *state, pic_value obj, bool tailpos)
   ARGC_ASSERT_GE(0);
   switch (pic_length(pic, obj)) {
   case 1:
-    return pic_int_value(0);
+    return pic_list2(pic, pic_symbol_value(pic->sQUOTE), pic_int_value(0));
   case 2:
     return analyze(state, pic_car(pic, pic_cdr(pic, obj)), tailpos);
   default:
@@ -598,7 +598,7 @@ analyze_mul(analyze_state *state, pic_value obj, bool tailpos)
   ARGC_ASSERT_GE(0);
   switch (pic_length(pic, obj)) {
   case 1:
-    return pic_int_value(1);
+    return pic_list2(pic, pic_symbol_value(pic->sQUOTE), pic_int_value(1));
   case 2:
     return analyze(state, pic_car(pic, pic_cdr(pic, obj)), tailpos);
   default:


### PR DESCRIPTION
Current picrin throws error when you give it `(+)` or `(*)`
