### PR TITLE
some bug fixes

### DIFF
--- a/piclib/built-in.scm
+++ b/piclib/built-in.scm
@@ -733,7 +733,7 @@
 	(end (if (>= (length opts) 2)
 		 (cadr opts)
 		 (vector-length v))))
-    (let ((res (make-vector (vector-length v))))
+    (let ((res (make-vector (- end start))))
       (vector-copy! res 0 v start end)
       res)))
 
@@ -792,7 +792,7 @@
 	(end (if (>= (length opts) 2)
 		 (cadr opts)
 		 (bytevector-length v))))
-    (let ((res (make-bytevector (bytevector-length v))))
+    (let ((res (make-bytevector (- end start))))
       (bytevector-copy! res 0 v start end)
       res)))
 

--- a/src/port.c
+++ b/src/port.c
@@ -467,12 +467,15 @@ pic_port_read_string(pic_state *pic){
 static pic_value
 pic_port_read_byte(pic_state *pic){
   struct pic_port *port = pic_stdin(pic);
-
+  char c;
   pic_get_args(pic, "|p", &port);
 
   assert_port_profile(port, PIC_PORT_IN | PIC_PORT_BINARY, PIC_PORT_OPEN, "read-u8");
+  if ((c = xfgetc(port->file)) == EOF) {
+    return pic_eof_object();
+  }
 
-  return pic_int_value((char) xfgetc(port->file));
+  return pic_int_value(c);
 }
 
 static pic_value


### PR DESCRIPTION
- `vector-copy` and `bytevector-copy`
  return correct length vector when start and/or end is given
- `u8-read`
  return EOF object if it is.
