### PR TITLE
Match the case of package name for find_package.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 list(APPEND REPL_LIBRARIES picrin)
 
-find_package(LIBEDIT)
+find_package(Libedit)
 if (Libedit_FOUND)
   include_directories(${Libedit_INCLUDE_DIRS})
   add_definitions(${Libedit_DEFINITIONS} -DPIC_READLINE_FOUND=1)


### PR DESCRIPTION
This mismatch causes build failure on Linux.
