### PR TITLE
silence warning from gc.c

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -533,8 +533,7 @@ gc_mark_phase(pic_state *pic)
 {
   pic_value *stack;
   pic_callinfo *ci;
-  size_t i;
-  int j;
+  size_t i, j;
   xh_iter it;
 
   /* block */


### PR DESCRIPTION
This warning is introduced by 2155a0c8f19b446fa6f10758270258e6a048fe8e.
