### PR TITLE
Issue: `string-set!` and `string-fill` is broken

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -388,7 +388,6 @@ pic_str_string_fill_ip(pic_state *pic)
   case 3:
     end = pic_strlen(str);
   }
-  printf("end %i\n", end);
   while (start < end) {
     pic_str_set(pic, str, start++, c);
   }

--- a/t/string.scm
+++ b/t/string.scm
@@ -1,0 +1,24 @@
+(import (scheme base)
+        (scheme write))
+
+;; master returns shorter string
+
+(let ((str (make-string 5 #\-)))
+  (string-set! str 2 #\x))
+
+;; this code prints right result
+(let ((str (make-string 5 #\-)))
+  (string-fill! str #\x)
+  (write str) (newline)
+  (string-fill! str #\y 1)
+  (write str) (newline)
+  (string-fill! str #\z 2 3)
+  (write str)) (newline)
+
+;; the last one prints shorter string
+(let ((str (make-string 5 #\-)))
+  (string-fill! str #\x)
+  (string-fill! str #\y 1)
+  (string-fill! str #\z 2 3)
+  (write str))
+


### PR DESCRIPTION
!!DO NOT MERGE!! this patch causes anther bug. Intended to make issue with code.

This patch fixes some bus but still `string-fill!` SOMETIMES returns shorter result. This may related to xrope's refcount bug. please investigate. You can refer reproducing code.
