### PR TITLE
Make filter tail-recursive

### DIFF
--- a/piclib/srfi/1.scm
+++ b/piclib/srfi/1.scm
@@ -402,12 +402,8 @@
   ;; filter partition remove
   ;; filter! partition! remove!
   (define (filter pred list)
-    (if (null? list)
-        '()
-        (if (pred (car list))
-            (cons (car list)
-                  (filter pred (cdr list)))
-            (filter pred (cdr list)))))
+    (let ((pcons (lambda (v acc) (if (pred v) (cons v acc) acc))))
+      (reverse (fold pcons '() list))))
 
   (define (remove pred list)
     (filter (lambda (x) (not (pred x))) list))


### PR DESCRIPTION
Function `filter` (in `piclib/srfi/1.scm`) is now tail-recursive.
