### PR TITLE
fix a bug of plus reader

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -278,7 +278,7 @@ read_plus(pic_state *pic, struct pic_port *port, char c)
   pic_value sym;
 
   if (isdigit(peek(port))) {
-    return read_number(pic, port, c);
+    return read_number(pic, port, next(port));
   }
   else {
     sym = read_symbol(pic, port, c);


### PR DESCRIPTION
Currently, `+1` raises an error.

If you merge this patch, you can unlock numeric syntax test for `+1`.
