### PR TITLE
Fast reader

### DIFF
--- a/include/picrin/read.h
+++ b/include/picrin/read.h
@@ -14,11 +14,20 @@ enum pic_typecase {
   PIC_CASE_FOLD,
 };
 
+enum pic_reader_type {
+  PIC_READER_C,
+  PIC_READER_PROC,
+};
+
 typedef pic_value pic_reader_func_t(pic_state *, struct pic_port *, const char *);
 
 struct pic_trie {
   struct pic_trie *table[256];
-  pic_reader_func_t *proc;
+  enum pic_reader_type type;
+  union {
+    pic_reader_func_t *func;
+    struct pic_proc *proc;
+  } u;
 };
 
 struct pic_reader {
@@ -29,7 +38,8 @@ struct pic_reader {
 
 void pic_init_reader(pic_state *);
 
-void pic_define_reader(pic_state *, const char *, pic_reader_func_t);
+void pic_define_reader_c(pic_state *, const char *, pic_reader_func_t);
+void pic_define_reader(pic_state *, const char *, struct pic_proc *);
 
 struct pic_trie *pic_trie_new(pic_state *);
 void pic_trie_delete(pic_state *, struct pic_trie *);

--- a/include/picrin/read.h
+++ b/include/picrin/read.h
@@ -14,9 +14,11 @@ enum pic_typecase {
   PIC_CASE_FOLD,
 };
 
+typedef pic_value pic_reader_func_t(pic_state *, struct pic_port *, const char *);
+
 struct pic_trie {
   struct pic_trie *table[256];
-  struct pic_proc *proc;
+  pic_reader_func_t *proc;
 };
 
 struct pic_reader {
@@ -27,7 +29,7 @@ struct pic_reader {
 
 void pic_init_reader(pic_state *);
 
-void pic_define_reader(pic_state *, const char *, pic_func_t);
+void pic_define_reader(pic_state *, const char *, pic_reader_func_t);
 
 struct pic_trie *pic_trie_new(pic_state *);
 void pic_trie_delete(pic_state *, struct pic_trie *);

--- a/src/gc.c
+++ b/src/gc.c
@@ -561,9 +561,9 @@ gc_mark_trie(pic_state *pic, struct pic_trie *trie)
       gc_mark_trie(pic, trie->table[i]);
     }
   }
-  if (trie->proc != NULL) {
-    gc_mark_object(pic, (struct pic_object *)trie->proc);
-  }
+  /* if (trie->proc != NULL) { */
+  /*   gc_mark_object(pic, (struct pic_object *)trie->proc); */
+  /* } */
 }
 
 static void


### PR DESCRIPTION
Current picrin reader allocates and soon frees dispatching string all the time when it meets new object. This makes picrin incredibly slow. Only if you stoped needles allocating, picrin gets faster by factor of more than 3.

master:
./bin/picrin ../t/r7rs-tests.scm
  15.98s user 0.10s system 99% cpu 16.129 total

fast-reader:
./bin/picrin ../t/r7rs-tests.scm
  4.90s user 0.10s system 99% cpu 5.035 total

I think `pic_reader_*`s aren't needed anymore so they're commented out but if you need (such times like when you want reader from scheme side), I'll restore.