### PR TITLE
Add CMake Policy settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 cmake_policy(VERSION 2.6)
-cmake_policy(SET CMP0037 OLD)
+if(POLICY CMP0037)
+  cmake_policy(SET CMP0037 OLD)
+endif()
 
 PROJECT(picrin)
 


### PR DESCRIPTION
I set version 2.6 as the baseline since cmake_minimum_required does so. CMP0037 denies target names reserved by generators, e.g. test.
