### PR TITLE
Improve error message for wrong number of arguments

### DIFF
--- a/extlib/benz/codegen.c
+++ b/extlib/benz/codegen.c
@@ -717,11 +717,12 @@ analyze_call_with_values(analyze_state *state, pic_value obj, bool tailpos)
   return pic_list3(pic, pic_symbol_value(call), prod, cnsm);
 }
 
-#define ARGC_ASSERT(n) do {				\
-	if (pic_length(pic, obj) != (n) + 1) {		\
-	  pic_errorf(pic, "wrong number of arguments");	\
-	}						\
-      } while (0)
+#define ARGC_ASSERT(n, name) do {                                       \
+    if (pic_length(pic, obj) != (n) + 1) {                              \
+      pic_errorf(pic, #name ": wrong number of arguments (%d for %d)",    \
+                 pic_length(pic, obj) - 1, n);                          \
+    }                                                                   \
+  } while (0)
 
 #define ARGC_ASSERT_WITH_FALLBACK(n) do {               \
 	if (pic_length(pic, obj) != (n) + 1) {		\
@@ -779,27 +780,27 @@ analyze_node(analyze_state *state, pic_value obj, bool tailpos)
         return analyze_quote(state, obj);
       }
       else if (sym == state->rCONS) {
-	ARGC_ASSERT(2);
+	ARGC_ASSERT(2, "cons");
         return CONSTRUCT_OP2(pic->sCONS);
       }
       else if (sym == state->rCAR) {
-	ARGC_ASSERT(1);
+	ARGC_ASSERT(1, "car");
         return CONSTRUCT_OP1(pic->sCAR);
       }
       else if (sym == state->rCDR) {
-	ARGC_ASSERT(1);
+	ARGC_ASSERT(1, "cdr");
         return CONSTRUCT_OP1(pic->sCDR);
       }
       else if (sym == state->rNILP) {
-	ARGC_ASSERT(1);
+	ARGC_ASSERT(1, "nil?");
         return CONSTRUCT_OP1(pic->sNILP);
       }
       else if (sym == state->rSYMBOL_P) {
-        ARGC_ASSERT(1);
+        ARGC_ASSERT(1, "symbol?");
         return CONSTRUCT_OP1(pic->sSYMBOL_P);
       }
       else if (sym == state->rPAIR_P) {
-        ARGC_ASSERT(1);
+        ARGC_ASSERT(1, "pair?");
         return CONSTRUCT_OP1(pic->sPAIR_P);
       }
       else if (sym == state->rADD) {
@@ -835,7 +836,7 @@ analyze_node(analyze_state *state, pic_value obj, bool tailpos)
         return CONSTRUCT_OP2(pic->sGE);
       }
       else if (sym == state->rNOT) {
-        ARGC_ASSERT(1);
+        ARGC_ASSERT(1, "not");
         return CONSTRUCT_OP1(pic->sNOT);
       }
       else if (sym == state->rVALUES) {

--- a/extlib/benz/codegen.c
+++ b/extlib/benz/codegen.c
@@ -704,7 +704,7 @@ analyze_call_with_values(analyze_state *state, pic_value obj, bool tailpos)
   pic_sym call;
 
   if (pic_length(pic, obj) != 3) {
-    pic_errorf(pic, "wrong number of arguments");
+    pic_errorf(pic, "call-with-values: wrong number of arguments (%d for 2)", pic_length(pic, obj) - 1);
   }
 
   if (! tailpos) {

--- a/extlib/benz/codegen.c
+++ b/extlib/benz/codegen.c
@@ -568,11 +568,14 @@ analyze_quote(analyze_state *state, pic_value obj)
   return pic_list2(pic, pic_sym_value(pic->sQUOTE), pic_list_ref(pic, obj, 1));
 }
 
-#define ARGC_ASSERT_GE(n) do {				\
-	if (pic_length(pic, obj) < (n) + 1) {		\
-	  pic_errorf(pic, "wrong number of arguments");	\
-	}						\
-      } while (0)
+#define ARGC_ASSERT_GE(n, name) do {                                    \
+    if (pic_length(pic, obj) < (n) + 1) {                               \
+      pic_errorf(pic,                                                   \
+                 #name ": wrong number of arguments (%d for equal to or more than %d)", \
+                 pic_length(pic, obj) - 1,                                  \
+                 n);                                                    \
+    }                                                                   \
+  } while (0)
 
 #define FOLD_ARGS(sym) do {                                             \
         obj = analyze(state, pic_car(pic, args), false);                \
@@ -588,7 +591,7 @@ analyze_add(analyze_state *state, pic_value obj, bool tailpos)
   pic_state *pic = state->pic;
   pic_value args, arg;
 
-  ARGC_ASSERT_GE(0);
+  ARGC_ASSERT_GE(0, "+");
   switch (pic_length(pic, obj)) {
   case 1:
     return pic_list2(pic, pic_symbol_value(pic->sQUOTE), pic_int_value(0));
@@ -607,7 +610,7 @@ analyze_sub(analyze_state *state, pic_value obj)
   pic_state *pic = state->pic;
   pic_value args, arg;
 
-  ARGC_ASSERT_GE(1);
+  ARGC_ASSERT_GE(1, "-");
   switch (pic_length(pic, obj)) {
   case 2:
     return pic_list2(pic, pic_symbol_value(pic->sMINUS),
@@ -625,7 +628,7 @@ analyze_mul(analyze_state *state, pic_value obj, bool tailpos)
   pic_state *pic = state->pic;
   pic_value args, arg;
 
-  ARGC_ASSERT_GE(0);
+  ARGC_ASSERT_GE(0, "*");
   switch (pic_length(pic, obj)) {
   case 1:
     return pic_list2(pic, pic_symbol_value(pic->sQUOTE), pic_int_value(1));
@@ -644,7 +647,7 @@ analyze_div(analyze_state *state, pic_value obj)
   pic_state *pic = state->pic;
   pic_value args, arg;
 
-  ARGC_ASSERT_GE(1);
+  ARGC_ASSERT_GE(1, "/");
   switch (pic_length(pic, obj)) {
   case 2:
     args = pic_cdr(pic, obj);


### PR DESCRIPTION
I fixed files I got with `grep 'wrong number' extlib/benz/*.c`. I think this is all but because some other (e.g. piclib) can raise its own error, this isn't necessarily perfect.