### PR TITLE
make benz's call/cc accessible from picrin

### DIFF
--- a/contrib/03.callcc/callcc.c
+++ b/contrib/03.callcc/callcc.c
@@ -287,6 +287,10 @@ pic_callcc_callcc(pic_state *pic)
 void
 pic_init_callcc(pic_state *pic)
 {
+  pic_deflibrary (pic, "(picrin control)") {
+    pic_define(pic, "escape", pic_ref(pic, pic->PICRIN_BASE, "call-with-current-continuation"));
+  }
+
   pic_deflibrary (pic, "(scheme base)") {
     pic_redefun(pic, pic->PICRIN_BASE, "call-with-current-continuation", pic_callcc_callcc);
     pic_redefun(pic, pic->PICRIN_BASE, "call/cc", pic_callcc_callcc);

--- a/contrib/10.partcont/docs/doc.rst
+++ b/contrib/10.partcont/docs/doc.rst
@@ -6,3 +6,6 @@ Delimited control operators.
 - **(reset h)**
 - **(shift k)**
 
+Escape Continuation
+
+- **(escape f)**

--- a/t/escape.scm
+++ b/t/escape.scm
@@ -1,0 +1,16 @@
+(import (scheme base)
+		(picrin control)
+        (picrin test))
+
+(test-begin)
+
+(test 1 (escape (lambda (exit) (begin (exit 1) 2))))
+
+(define cont #f)
+
+(test "calling dead escape continuation"
+	  (guard (c ((error-object? c) (error-object-message c)))
+			 (escape (lambda (exit) (set! cont exit)))
+			 (cont 3)))
+
+(test-end)


### PR DESCRIPTION
benz's `call/cc` is limited in its usage, but much lighter than pictin's. I propose renaming bent'z `call/cc` to `escape` in `(picrin control)`, to make it accessible from picrin.