### PR TITLE
Issue 257

### DIFF
--- a/extlib/benz/pair.c
+++ b/extlib/benz/pair.c
@@ -643,7 +643,11 @@ pic_pair_map(pic_state *pic)
   pic_value *args;
   pic_value arg, ret;
 
+  argc = 0;
   pic_get_args(pic, "l*", &proc, &argc, &args);
+
+  if (argc == 0)
+    pic_errorf(pic, "map: wrong number of arguments (1 for at least 2)");
 
   ret = pic_nil_value();
   do {
@@ -655,6 +659,7 @@ pic_pair_map(pic_state *pic)
       pic_push(pic, pic_car(pic, args[i]), arg);
       args[i] = pic_cdr(pic, args[i]);
     }
+
     if (i != argc) {
       break;
     }

--- a/extlib/benz/pair.c
+++ b/extlib/benz/pair.c
@@ -643,7 +643,6 @@ pic_pair_map(pic_state *pic)
   pic_value *args;
   pic_value arg, ret;
 
-  argc = 0;
   pic_get_args(pic, "l*", &proc, &argc, &args);
 
   if (argc == 0)

--- a/t/issue/257.scm
+++ b/t/issue/257.scm
@@ -1,0 +1,4 @@
+(import (scheme base)
+        (picrin test))
+
+(map +)


### PR DESCRIPTION
This is a bit dirty. The cause was L651 `for`. When argc is 0, `++i` is never executed and stay equal to argc eternally. Thus I treated `argc == 0` specially.

Any cleaner hack?