### PR TITLE
Make vector-map{,!} SRFI 43-compliant

### DIFF
--- a/contrib/10.srfi/srfi/43.scm
+++ b/contrib/10.srfi/srfi/43.scm
@@ -1,5 +1,5 @@
 (define-library (srfi 43)
-  (import (scheme base)
+  (import (except (scheme base) vector-map)
           (srfi 8))
   
   ;; # Constructors

--- a/contrib/10.srfi/srfi/43.scm
+++ b/contrib/10.srfi/srfi/43.scm
@@ -92,16 +92,28 @@
                         (map (lambda (v) (vector-ref v count)) vects))
                  (- count 1))))))
 
-  (define (vector-map! f vec . vects)
+  (define (vector-map f vec . vects)
     (let* ((vects (cons vec vects))
            (veclen (apply min (map vector-length vects)))
            (new-vect (make-vector veclen)))
       (let rec ((count 0))
+        (if (= count veclen)
+            new-vect
+            (begin
+              (vector-set! new-vect count
+                           (apply f count (map (lambda (v) (vector-ref v count))
+                                               vects)))
+              (rec (+ 1 count)))))))
+
+  (define (vector-map! f vec . vects)
+    (let* ((vects (cons vec vects))
+           (veclen (apply min (map vector-length vects))))
+      (let rec ((count 0))
         (if (< count veclen)
             (begin
               (vector-set! vec count
-                           (apply f (map (lambda (v) (vector-ref v count))
-                                         vects)))
+                           (apply f count (map (lambda (v) (vector-ref v count))
+                                               vects)))
               (rec (+ 1 count)))))))
 
   (define (vector-count pred? vec . vects)


### PR DESCRIPTION
This PR includes a patch from #175 with a patch to pass the tests.

I'm unsure the current behavior (any definition in a nitro can be overridden from one in another nitro) is by design or not. (is it an undefined behavior in R7RS?)
Anyway, we have no need to import `vector-map` in SRFI 43. Are you happy with this? @stibear

Fixes #175.