### PR TITLE
Rename C part of SRFI 106 to (srfi 106 impl).

### DIFF
--- a/contrib/40.srfi/src/106.c
+++ b/contrib/40.srfi/src/106.c
@@ -399,7 +399,7 @@ pic_socket_call_with_socket(pic_state *pic)
 void
 pic_init_socket(pic_state *pic)
 {
-  pic_deflibrary (pic, "(srfi 106)") {
+  pic_deflibrary (pic, "(srfi 106 impl)") {
     pic_defun(pic, "socket?", pic_socket_socket_p);
     pic_defun(pic, "make-socket", pic_socket_make_socket);
     pic_defun(pic, "socket-accept", pic_socket_socket_accept);

--- a/contrib/40.srfi/srfi/106.scm
+++ b/contrib/40.srfi/srfi/106.scm
@@ -1,6 +1,7 @@
 (define-library (srfi 106)
   (import (scheme base)
           (srfi 60)
+          (srfi 106 impl)
           (picrin optional))
 
   ; TODO: Define assq-ref anywhere else.


### PR DESCRIPTION
(srfi 106) exported `make-socket` accidentally. The procedure should be treated as an implementation detail, so now 106.c defines another library. 106.scm re-exports all public identifiers, so it should be fine.