### PR TITLE
Rename initialize funtions of SRFIs to srfi_<n>.

### DIFF
--- a/contrib/40.srfi/nitro.mk
+++ b/contrib/40.srfi/nitro.mk
@@ -1,4 +1,6 @@
-CONTRIB_INITS += features socket
+CONTRIB_INITS += \
+	srfi_0 \
+	srfi_106
 CONTRIB_LIBS += \
 	contrib/40.srfi/srfi/0.scm\
 	contrib/40.srfi/srfi/1.scm\

--- a/contrib/40.srfi/src/0.c
+++ b/contrib/40.srfi/src/0.c
@@ -1,7 +1,7 @@
 #include "picrin.h"
 
 void
-pic_init_features(pic_state *pic)
+pic_init_srfi_0(pic_state *pic)
 {
     pic_add_feature(pic, "srfi-0");
     pic_add_feature(pic, "srfi-1");

--- a/contrib/40.srfi/src/106.c
+++ b/contrib/40.srfi/src/106.c
@@ -397,7 +397,7 @@ pic_socket_call_with_socket(pic_state *pic)
 }
 
 void
-pic_init_socket(pic_state *pic)
+pic_init_srfi_106(pic_state *pic)
 {
   pic_deflibrary (pic, "(srfi 106)") {
     pic_defun_(pic, "socket?", pic_socket_socket_p);


### PR DESCRIPTION
To avoid conflictions of inits between SRFIs and others, inits in the srfi nitro should be prefixed with srfi_. Without the convention, we may need to use generic words such as string, vector, random, array, etc.

Moreover, there are SRFIs those subject is same (e.g. array may be used by SRFI 25, 47, 58 and 63). Thus, we need a clear and conflict-free naming convention.