### PR TITLE
Use container-based infrastructure of Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
+sudo: false
 language: c
 compiler:
   - gcc
   - clang
+addons:
+  apt:
+    packages:
+      - gcc-multilib
 env:
   - CFLAGS="-m32"
   - CFLAGS="-m64"
-before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y gcc-multilib
 script:
   - perl --version
   - make test


### PR DESCRIPTION
It's faster than standard (hypervisor-based) one, so we will benefit from it, especially when we want larger build matrix.

I thought we can't use it since it restricts the use of ``sudo``. However, Travis provides ``addon`` feature to install additional packages from container-based infrastructure.

References:
http://docs.travis-ci.com/user/workers/container-based-infrastructure/
http://docs.travis-ci.com/user/apt/