### PR TITLE
Allow to pass environment variable for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TEST_RUNNER = bin/picrin
 CFLAGS += -I./extlib/benz/include -Wall -Wextra
 LDFLAGS += -lm
 
-prefix = /usr/local
+prefix ?= /usr/local
 
 all: CFLAGS += -O2 -DNDEBUG=1
 all: bin/picrin


### PR DESCRIPTION
Current Makefile doesn't allow users to install desirable location other than `/usr/local` without modifying Makefile. This change considers environment variable of  `prefix` so that users can specify where it needs to be installed.