### PR TITLE
Fix Makefile and one test for correct behavior.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,9 @@ test-nostdlib:
 test-issue: test-picrin-issue test-repl-issue
 
 test-picrin-issue: $(TEST_RUNNER) $(PICRIN_ISSUE_TESTS)
-	$(TEST_RUNNER) $(PICRIN_ISSUE_TESTS)
+	for test in $(PICRIN_ISSUE_TESTS); do \
+	  $(TEST_RUNNER) "$$test"; \
+	done
 
 test-repl-issue: $(REPL_ISSUE_TESTS)
 

--- a/t/parameterize.scm
+++ b/t/parameterize.scm
@@ -1,4 +1,5 @@
 (import (scheme base)
+        (scheme write)
         (picrin test))
 
 (test-begin)


### PR DESCRIPTION
The make target `test-picrin-issue` was only loading the first of several files due to the way `main` works. This changes uses an iterator in the Makefile like the contribs.

Also added a necessary import for t/parameterize.scm