### PR TITLE
Reduce size of data object by removing unused dict field

### DIFF
--- a/extlib/benz/data.c
+++ b/extlib/benz/data.c
@@ -4,12 +4,10 @@ struct pic_data *
 pic_data_alloc(pic_state *pic, const pic_data_type *type, void *userdata)
 {
   struct pic_data *data;
-  struct pic_dict *storage = pic_make_dict(pic);
 
   data = (struct pic_data *)pic_obj_alloc(pic, sizeof(struct pic_data), PIC_TT_DATA);
   data->type = type;
   data->data = userdata;
-  data->storage = storage;
 
   return data;
 }

--- a/extlib/benz/gc.c
+++ b/extlib/benz/gc.c
@@ -375,7 +375,6 @@ gc_mark_object(pic_state *pic, struct pic_object *obj)
     if (obj->u.data.type->mark) {
       obj->u.data.type->mark(pic, obj->u.data.data, gc_mark);
     }
-    LOOP(obj->u.data.storage);
     break;
   }
   case PIC_TT_DICT: {

--- a/extlib/benz/include/picrin/data.h
+++ b/extlib/benz/include/picrin/data.h
@@ -18,7 +18,6 @@ typedef struct {
 struct pic_data {
   PIC_OBJECT_HEADER
   const pic_data_type *type;
-  struct pic_dict *storage;
   void *data;
 };
 


### PR DESCRIPTION
`struct pic_data` has a `dict` field that is initialized but never referenced. This patch removes that field.