### PR TITLE
Fix roundtrip -0.0

### DIFF
--- a/contrib/10.roundtrip/emyg_dtoa.c
+++ b/contrib/10.roundtrip/emyg_dtoa.c
@@ -426,12 +426,8 @@ void emyg_dtoa (double value, char* buffer) {
     strcpy(buffer, signbit(value) ? "-inf.0" : "+inf.0");
   else if (isnan(value))
     strcpy(buffer, signbit(value) ? "-nan.0" : "+nan.0");
-  else if (value == 0) {
-    buffer[0] = '0';
-    buffer[1] = '.';
-    buffer[2] = '0';
-    buffer[3] = '\0';
-  }
+  else if (value == 0)
+    strcpy(buffer, signbit(value) ? "-0.0" : "0.0");
   else {
     if (value < 0) {
       *buffer++ = '-';

--- a/contrib/10.roundtrip/t/roundtrip.scm
+++ b/contrib/10.roundtrip/t/roundtrip.scm
@@ -17,6 +17,12 @@
 
 (test #t (rountrip-ok +inf.0))
 
+(test #t (rountrip-ok +0.0))
+
+(test #t (rountrip-ok -0.0))
+
+(test #t (rountrip-ok 0.0))
+
 (test -inf.0 (string->number "-inf.0"))
 
 (test +inf.0 (string->number "+inf.0"))


### PR DESCRIPTION
The dtoa code was not printing a '-' for `-0.0`; this is now fixed, and test cases added.