### PR TITLE
run `make` before run `make test` to test the binary built for usual use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - CFLAGS="-m64"
 script:
   - perl --version
+  - make
   - make test
 # - make test-contrib TEST_RUNNER="valgrind -q --leak-check=full --dsymutil=yes --error-exitcode=1 bin/picrin"
   - make clean


### PR DESCRIPTION
@wasabiz 

current `make test` only depends on `bin/picrin` and it by-passes `all`'s `CFLAGS += -O2 -DNDEBUG=1`. It is OK, because you need to test against both `make all` and `make test`.
Then, let's modify CI code.