### PR TITLE
Restrict char in the range of ASCII.

### DIFF
--- a/extlib/benz/char.c
+++ b/extlib/benz/char.c
@@ -22,6 +22,7 @@ pic_char_char_to_integer(pic_state *pic)
   char c;
 
   pic_get_args(pic, "c", &c);
+  assert((c & 0x80) == 0);
 
   return pic_int_value(pic, c);
 }
@@ -33,7 +34,7 @@ pic_char_integer_to_char(pic_state *pic)
 
   pic_get_args(pic, "i", &i);
 
-  if (i < 0 || i > 255) {
+  if (i < 0 || i > 127) {
     pic_error(pic, "integer->char: integer out of char range", 1, pic_int_value(pic, i));
   }
   


### PR DESCRIPTION
picrin accepts the code `(char->integer (integer->char 128))` but the result is machine-dependent, since the C `char` type can be either signed or unsigned as permitted by the spec. Unfortunately, the result of signed one is incompatible with Unicode-aware implementations. For interoperability, we should deny the range beyond ASCII for now.

Ref: #211