### PR TITLE
Fix make-syntactic-closure

### DIFF
--- a/contrib/10.macro/macro.scm
+++ b/contrib/10.macro/macro.scm
@@ -62,7 +62,7 @@
           ((f (lambda (var)
                 (let loop ((free free))
                   (if (null? free)
-                      (wrap free)
+                      (wrap var)
                       (if (identifier=? var (car free))
                           var
                           (loop (cdr free))))))))


### PR DESCRIPTION
make-syntactic-closure raises an error when it takes identifiers.
The following session demonstrates the error.

> (define-macro a (sc-macro-transformer (lambda (form use-env) 'foo)))
#undefined
> (a)
error: attempted to set a non-object key '()' in a register