### PR TITLE
Makefile: Remove redirected target on fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,17 +64,17 @@ picrin: $(PICRIN_OBJS) $(CONTRIB_OBJS) $(LIBPICRIN_OBJS)
 	$(CC) $(CFLAGS) -o $@ $(PICRIN_OBJS) $(CONTRIB_OBJS) $(LIBPICRIN_OBJS) $(LDFLAGS)
 
 src/load_piclib.c: $(CONTRIB_LIBS)
-	perl tools/mkloader.pl $(CONTRIB_LIBS) > $@
+	perl tools/mkloader.pl $(CONTRIB_LIBS) > $@ || (rm $@; false)
 
 src/init_contrib.c:
-	perl tools/mkinit.pl $(CONTRIB_INITS) > $@
+	perl tools/mkinit.pl $(CONTRIB_INITS) > $@ || (rm $@; false)
 
 # FIXME: Undefined symbols error for _emyg_atod and _emyg_dtoa
 # libpicrin.so: $(LIBPICRIN_OBJS)
 # 	$(CC) -shared $(CFLAGS) -o $@ $(LIBPICRIN_OBJS) $(LDFLAGS)
 
 lib/boot.c: piclib/boot.scm
-	bin/picrin-bootstrap tools/mkboot.scm < piclib/boot.scm > lib/boot.c
+	bin/picrin-bootstrap tools/mkboot.scm < piclib/boot.scm > $@ || (rm $@; false)
 
 $(LIBPICRIN_OBJS) $(PICRIN_OBJS) $(CONTRIB_OBJS): lib/include/picrin.h lib/include/picrin/*.h lib/khash.h lib/object.h lib/state.h lib/vm.h
 


### PR DESCRIPTION
When we use shell-redirection to generate target in `Makefile`, we have to remove failed output explicitly. Otherwise, we will get empty file as target even on failure case and next `make` invocation may fail on wrong place.

NOTE: Since I don't have OSX box right now, the patch haven't tested at all. (https://github.com/picrin-scheme/picrin/commit/d66ce6413018f31ac34c87b4c7a6b54daa72939b requires OSX to build the repository)

Alternatively, you may use `.DELETE_ON_ERROR` special target ( http://stackoverflow.com/questions/3587182 ) but it is `gmake` extension and I do not recommend doing so.