### PR TITLE
Harmonize Perl scripts

### DIFF
--- a/lib/ext/boot.c
+++ b/lib/ext/boot.c
@@ -363,7 +363,9 @@ static const char boot_rom[][80] = {
 "       (lambda (expr . lib)\n            (let ((lib (if (null? lib) (current-libr",
 "ary) (car lib))))\n              (e expr (library-environment lib))))))\n  (make-l",
 "ibrary '(picrin user))\n  (current-library '(picrin user)))\n\n",
+"",
 };
+
 
 void
 pic_boot(pic_state *pic)

--- a/tools/mkloader.pl
+++ b/tools/mkloader.pl
@@ -3,6 +3,21 @@
 use strict;
 use File::Basename qw/basename dirname/;
 
+sub constant($$) {
+    # The maximum length of a string literal is 509 characters in C89.
+    # That is why src is split into short strings.
+    my ($var, $src) = @_;
+    print "static const char ${var}[][80] = {\n";
+    my @lines = $src =~ /.{0,80}/gs;
+    foreach (@lines) {
+        s/\\/\\\\/g;
+        s/"/\\"/g;
+        s/\n/\\n/g;
+        print "\"$_\",\n";
+    }
+    print "};\n\n";
+}
+
 print <<EOL;
 /**
  *                                !!NOTICE!!
@@ -18,21 +33,11 @@ EOL
 
 foreach my $file (@ARGV) {
     my $var = &escape_v($file);
-    print "static const char ${var}[][80] = {\n";
-
     open IN, $file;
     local $/ = undef;
     my $src = <IN>;
     close IN;
-
-    my @lines = $src =~ /.{0,80}/gs;
-    foreach (@lines) {
-        s/\\/\\\\/g;
-        s/"/\\"/g;
-        s/\n/\\n/g;
-        print "\"$_\",\n";
-    }
-    print "};\n\n";
+    constant($var, $src);
 }
 
 print <<EOL;


### PR DESCRIPTION
mkloader.pl and mkboot.pl encode a C string the same way. This job is now done in the constant() subroutine, identical in both scripts.